### PR TITLE
stage_err - add support for reporting staging errors to data waiters

### DIFF
--- a/src/ioctl.h
+++ b/src/ioctl.h
@@ -346,5 +346,20 @@ struct scoutfs_ioctl_statfs_more {
 #define SCOUTFS_IOC_STATFS_MORE _IOR(SCOUTFS_IOCTL_MAGIC, 10, \
 				     struct scoutfs_ioctl_statfs_more)
 
+/*
+ * Cause the offline data waiters within the specified range to report an error.
+ *
+ * Given the offline data waiter with inode version @version, cause any offline
+ * data waiters in the @start_offset to @end_offset byte range to return @err.
+ */
+struct scoutfs_ioctl_stage_err {
+	__u64 data_version;
+	__u64 start_offset;
+	__u64 end_offset;
+	__s64 err;
+};
+
+#define SCOUTFS_IOC_STAGE_ERR _IOW(SCOUTFS_IOCTL_MAGIC, 11, \
+				   struct scoutfs_ioctl_stage_err)
 
 #endif

--- a/src/sparse.h
+++ b/src/sparse.h
@@ -33,6 +33,7 @@ typedef u16 __u16;
 typedef u32 __u32;
 typedef s32 __s32;
 typedef u64 __u64;
+typedef s64 __s64;
 
 typedef u16 __sp_biwise __le16;
 typedef u16 __sp_biwise __be16;


### PR DESCRIPTION
Add support for reporting staging errors to offline data waiters via a
new SCOUTFS_IOC_STAGE_ERR ioctl.  This allows waiters to return an
error to readers when staging fails.

	scoutfs stage_err <file> <vers> <start> <end> <err>

Where start & end specify the range in bytes, and where err is a negative error
return number - ie -5 = EIO.

Signed-off-by: Benjamin LaHaise <bcrl@kvack.org>